### PR TITLE
Add System secret storage talk-names in flatpak

### DIFF
--- a/packaging/flatpak/manifest-template.yml
+++ b/packaging/flatpak/manifest-template.yml
@@ -33,7 +33,6 @@ finish-args:
   # Since this is electron, we also need access to the actual keystore DBuses
   - --talk-name=org.kde.kwalletd5
   - --talk-name=org.kde.kwalletd6
-  - --talk-name=org.gnome.SessionManager
   # Use native Wayland if available
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 build-options:

--- a/packaging/flatpak/manifest-template.yml
+++ b/packaging/flatpak/manifest-template.yml
@@ -30,6 +30,10 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   # Allow writing to system secrets storage
   - --talk-name=org.freedesktop.secrets
+  # Since this is electron, we also need access to the actual keystore DBuses
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
+  - --talk-name=org.gnome.SessionManager
   # Use native Wayland if available
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 build-options:


### PR DESCRIPTION
Electron safeStorage uses the Chromium OSCrypto implementation. This causes calls on the kwalletd and gnome keyring DBuses to check if they are enabled (see code at https://chromium.googlesource.com/chromium/src/+/refs/tags/140.0.7331.1/components/os_crypt/sync/key_storage_kwallet.cc for example). Without adding the talk names, safeStorage cannot use encryption due to the init failing on flatpak installations.

See Chromium flatpak spec at https://github.com/flathub/org.chromium.Chromium/blob/d870b2845f8aa5d94aad433c812f0768c8db26b4/org.chromium.Chromium.yaml#L28