### PR TITLE
macOS: Deselect active chat when closing window

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -527,6 +527,14 @@ async function main(): Promise<() => Promise<void>> {
     };
     appServices.set(services);
 
+    if (systemInfo.os === 'macos') {
+        electron.registerOnMacosWindowCloseCallback(() => {
+            if (services.router.get().main.id === 'conversation') {
+                services.router.goToWelcome();
+            }
+        });
+    }
+
     // If this identity is ready, resolve `identityReady` promise
     if (identityIsReady) {
         identityReady.resolve();

--- a/src/common/dom/electron-service.ts
+++ b/src/common/dom/electron-service.ts
@@ -195,6 +195,11 @@ export class ElectronIpcService implements ElectronIpc {
     }
 
     /** @inheritdoc */
+    public registerOnMacosWindowCloseCallback(callback: () => void): void {
+        window.app.registerOnMacosWindowCloseCallback(callback);
+    }
+
+    /** @inheritdoc */
     public updateAppBadge(totalUnreadMessageCount: u53): void {
         window.app.updateAppBadge(totalUnreadMessageCount);
     }

--- a/src/common/electron-ipc.ts
+++ b/src/common/electron-ipc.ts
@@ -225,6 +225,11 @@ export interface ElectronIpc {
     readonly registerOnScreenSharingStopCallback: (callback: () => void) => void;
 
     /**
+     * Register a callback for the macOS window close action before the main window is hidden.
+     */
+    readonly registerOnMacosWindowCloseCallback: (callback: () => void) => void;
+
+    /**
      * Register a callback for `on-suspend` and `on-lock` events.
      */
     readonly registerOnSuspendCallback: (callback: () => Promise<void>) => void;

--- a/src/common/enum/index.ts
+++ b/src/common/enum/index.ts
@@ -3077,6 +3077,8 @@ export namespace ElectronIpcCommand {
     export type SCREEN_SHARING_PRESENT_PICKER = typeof SCREEN_SHARING_PRESENT_PICKER;
     export const SCREEN_SHARING_SCREEN_SELECTED = 'screenSharingScreenSelected';
     export type SCREEN_SHARING_SCREEN_SELECTED = typeof SCREEN_SHARING_SCREEN_SELECTED;
+    export const MACOS_WINDOW_CLOSE = 'macosWindowClose';
+    export type MACOS_WINDOW_CLOSE = typeof MACOS_WINDOW_CLOSE;
     export const SYSTEM_SUSPENDING = 'systemSuspending';
     export type SYSTEM_SUSPENDING = typeof SYSTEM_SUSPENDING;
 }

--- a/src/electron/electron-main.ts
+++ b/src/electron/electron-main.ts
@@ -1141,6 +1141,7 @@ function main(
         window.on('close', (event) => {
             const currentWindow = unwrap(window, 'Window is undefined in on:close');
             if (process.platform === 'darwin' && !forceQuit) {
+                currentWindow.webContents.send(ElectronIpcCommand.MACOS_WINDOW_CLOSE);
                 // On macOS don't quit app if window was closed
                 event.preventDefault();
                 currentWindow.hide();

--- a/src/electron/electron-preload.ts
+++ b/src/electron/electron-preload.ts
@@ -88,6 +88,8 @@ const appApi: ElectronIpc = {
         ),
     registerOnScreenSharingStopCallback: (callback: () => void) =>
         ipcRenderer.on(ElectronIpcCommand.SCREEN_SHARING_STOP, () => callback()),
+    registerOnMacosWindowCloseCallback: (callback: () => void) =>
+        ipcRenderer.on(ElectronIpcCommand.MACOS_WINDOW_CLOSE, () => callback()),
     registerOnSuspendCallback: (callback: () => void) =>
         ipcRenderer.on(ElectronIpcCommand.SYSTEM_SUSPENDING, () => callback()),
 };

--- a/src/enum/schema.ts
+++ b/src/enum/schema.ts
@@ -972,6 +972,7 @@ export enum ElectronIpcCommand {
     SCREEN_SHARING_STOP = 'screenSharingStop',
     SCREEN_SHARING_PRESENT_PICKER = 'screenSharingPresentPicker',
     SCREEN_SHARING_SCREEN_SELECTED = 'screenSharingScreenSelected',
+    MACOS_WINDOW_CLOSE = 'macosWindowClose',
     SYSTEM_SUSPENDING = 'systemSuspending',
 }
 

--- a/src/test/karma/app/router.spec.ts
+++ b/src/test/karma/app/router.spec.ts
@@ -186,6 +186,33 @@ export function run(): void {
             router.assertRouteIds({nav: 'conversationList', main: 'welcome'});
         });
 
+        it('goToWelcome closes aside and modal when leaving a conversation', function () {
+            const router = new TestRouter();
+            const receiverLookup = {type: ReceiverType.CONTACT, uid: 42n as DbContactUid};
+
+            router.go({
+                main: ROUTE_DEFINITIONS.main.conversation.withParams({receiverLookup}),
+                aside: ROUTE_DEFINITIONS.aside.contactDetails.withParams(receiverLookup),
+                modal: ROUTE_DEFINITIONS.modal.changePassword.withoutParams(),
+            });
+            router.assertRouteIds({
+                nav: 'conversationList',
+                main: 'conversation',
+                aside: 'contactDetails',
+                modal: 'changePassword',
+            });
+
+            router.goToWelcome();
+
+            router.assertRouteIds({
+                nav: 'conversationList',
+                main: 'welcome',
+                aside: undefined,
+                modal: undefined,
+                activity: undefined,
+            });
+        });
+
         describe('assert', function () {
             it('can successfully assert a route', function () {
                 const router = new TestRouter();


### PR DESCRIPTION
**New behavior:**
On macOS, closing the window now also deselects the currently open chat, so reopening the app shows the welcome view instead of the previously active conversation.
This mirrors WhatsApp’s behavior on macOS, which I personally prefer.

If someone prefers to keep the current chat open while hiding the app, Cmd+H is still available and continues to work well for that.

**What this solves:**
With many messages coming in all the time this new behavior makes sure that I don't have to mark chats to unread when I reopen the window and happen to be inside a chat I actually don't want to be in right now, but it also has an unread message.
Before this change I usually clicked the chat or double-clicked any chat to keep everything on unread next time I open the window.

**Note:**
I'm not at all familiar with the codebase and this is completely vibe-coded, but I checked the code manually as well and I guess this might be the right way to do it and I've made sure that it still compiles on macOS and runs fine on my machine with the intended new behavior.
If this is not fine, please take this PR as a feature request.

Thank you.